### PR TITLE
fixed test to use updated Event class

### DIFF
--- a/code/app/src/test/java/com/example/yellow/EventDetailsFragmentTest.java
+++ b/code/app/src/test/java/com/example/yellow/EventDetailsFragmentTest.java
@@ -237,6 +237,7 @@ public class EventDetailsFragmentTest {
                         (String)data.get("description"),
                         (String)data.get("location"),
                         new Timestamp(new Date()), new Timestamp(new Date()),
+                        new Timestamp(new Date()), new Timestamp(new Date()),
                         "",
                         1,
                         1,


### PR DESCRIPTION
EventDetailsFragmentTest used a mock Event, but the number of arguments for its constructor changed. It should work now.